### PR TITLE
Add SEO-optimized imageAlt support for blog post images

### DIFF
--- a/src/content/blog/advisor-to-the-board-of-directors-job-description.md
+++ b/src/content/blog/advisor-to-the-board-of-directors-job-description.md
@@ -5,6 +5,7 @@ pubDate: 2024-11-03
 author: "Jean-Louis Van Houwe"
 authorRole: "CEO & Founder at Govrn"
 image: "/boussole.jpg"
+imageAlt: "Advisor to the board of directors job description: Strategic guidance compass for corporate governance and board decision-making excellence"
 category: "Governance"
 tags: ["Board Advisors", "Corporate Governance", "Decision-Making", "Leadership"]
 featured: false

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -9,6 +9,7 @@ const blog = defineCollection({
     author: z.string(),
     authorRole: z.string(),
     image: z.string(),
+    imageAlt: z.string().optional(),
     category: z.enum(['Governance', 'Technology', 'Best Practices', 'Industry Insights', 'Regulatory']),
     tags: z.array(z.string()),
     featured: z.boolean().optional().default(false),

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -75,7 +75,7 @@ const structuredData = {
           <div class="absolute inset-0 bg-gradient-to-tr from-primary/20 to-transparent"></div>
           <Image
             src={heroImage}
-            alt={entry.data.title}
+            alt={entry.data.imageAlt || entry.data.title}
             widths={[640, 960, 1200]}
             sizes="(max-width: 640px) 640px, (max-width: 1024px) 960px, 1200px"
             class="w-full h-full object-cover"


### PR DESCRIPTION
### Summary

Added support for custom SEO-optimized alt attributes for blog post images. Blog authors can now specify an optional `imageAlt` field in the front matter to provide SEO-friendly alt text for their blog post hero images.

### Changes

- Added optional `imageAlt` field to blog post schema
- Updated blog template to use custom alt text when provided
- Added SEO-friendly alt text to advisor blog post including target keyword 'advisor to the board of directors job description'
- Maintains backward compatibility with existing posts

### Usage

Blog authors can add the `imageAlt` field to any blog post's front matter:

```yaml
---
title: "My Blog Post Title"
image: "/my-image.jpg"
imageAlt: "SEO-optimized alt text with relevant keywords"
---
```

If `imageAlt` is not provided, the blog post title will be used as the alt text (current behavior).

Fixes #7

---

Generated with [Claude Code](https://claude.ai/code)