### PR TITLE
Add Family Business industry to navigation and overview

### DIFF
--- a/src/components/navigation/MegaMenu.astro
+++ b/src/components/navigation/MegaMenu.astro
@@ -32,14 +32,14 @@ const industries = {
   en: [
     {
       name: "Financial Services",
-      icon: "🏦", 
+      icon: "🏦",
       description: "Banking, Insurance, and Investment firms",
       href: "/industries/financial-services",
     },
     {
       name: "Healthcare",
       icon: "🏥",
-      description: "Hospitals, Medical Devices, and Healthcare providers", 
+      description: "Hospitals, Medical Devices, and Healthcare providers",
       href: "/industries/healthcare",
     },
     {
@@ -47,6 +47,12 @@ const industries = {
       icon: "🏢",
       description: "Property Investment and Management",
       href: "/industries/real-estate",
+    },
+    {
+      name: "Family Business",
+      icon: "👨‍👩‍👧‍👦",
+      description: "Multi-entity governance for family businesses",
+      href: "/industries/family-business",
     }
   ],
   fr: [
@@ -58,7 +64,7 @@ const industries = {
     },
     {
       name: "Santé",
-      icon: "🏥", 
+      icon: "🏥",
       description: "Hôpitaux, Dispositifs médicaux et Prestataires de soins",
       href: "/fr/industries/healthcare",
     },
@@ -66,7 +72,13 @@ const industries = {
       name: "Immobilier",
       icon: "🏢",
       description: "Investissement et Gestion immobilière",
-      href: "/fr/industries/real-estate", 
+      href: "/fr/industries/real-estate",
+    },
+    {
+      name: "Entreprise Familiale",
+      icon: "👨‍👩‍👧‍👦",
+      description: "Gouvernance multi-entités pour entreprises familiales",
+      href: "/fr/industries/family-business",
     }
   ],
   nl: [
@@ -84,9 +96,15 @@ const industries = {
     },
     {
       name: "Vastgoed",
-      icon: "🏢", 
+      icon: "🏢",
       description: "Vastgoedinvestering en -beheer",
       href: "/nl/industries/real-estate",
+    },
+    {
+      name: "Familiebedrijf",
+      icon: "👨‍👩‍👧‍👦",
+      description: "Multi-entiteit governance voor familiebedrijven",
+      href: "/nl/industries/family-business",
     }
   ]
 }[lang];

--- a/src/pages/fr/industries/index.astro
+++ b/src/pages/fr/industries/index.astro
@@ -4,7 +4,7 @@ import Layout from '../../../layouts/Layout.astro';
 const industries = [
   {
     name: "Services financiers",
-    icon: "🏦", 
+    icon: "🏦",
     description: "Gestion de conseil sécurisée et conforme pour les banques, assurances et sociétés d'investissement",
     link: "/fr/industries/financial-services",
     features: [
@@ -17,7 +17,7 @@ const industries = [
     name: "Santé",
     icon: "🏥",
     description: "Solutions conformes aux normes de confidentialité pour les établissements de santé",
-    link: "/fr/industries/healthcare", 
+    link: "/fr/industries/healthcare",
     features: [
       "Protection des données de santé",
       "Gouvernance clinique",
@@ -31,8 +31,19 @@ const industries = [
     link: "/fr/industries/real-estate",
     features: [
       "Supervision du portefeuille",
-      "Suivi des investissements", 
+      "Suivi des investissements",
       "Gestion des actifs"
+    ]
+  },
+  {
+    name: "Entreprise familiale",
+    icon: "👨‍👩‍👧‍👦",
+    description: "Gestion du conseil et du conseil de famille pour entreprises familiales multi-entités",
+    link: "/fr/industries/family-business",
+    features: [
+      "Gouvernance multi-entités",
+      "Contrôle d'accès sécurisé",
+      "Continuité générationnelle"
     ]
   }
 ];

--- a/src/pages/industries/index.astro
+++ b/src/pages/industries/index.astro
@@ -34,6 +34,17 @@ const industries = [
       "Investment tracking",
       "Asset management"
     ]
+  },
+  {
+    name: "Family Business",
+    icon: "👨‍👩‍👧‍👦",
+    description: "Board and family council management for multi-entity family businesses",
+    link: "/industries/family-business",
+    features: [
+      "Multi-entity governance",
+      "Secure access control",
+      "Generational continuity"
+    ]
   }
 ];
 ---

--- a/src/pages/nl/industries/index.astro
+++ b/src/pages/nl/industries/index.astro
@@ -15,7 +15,7 @@ const industries = [
   },
   {
     name: "Gezondheidszorg",
-    icon: "🏥", 
+    icon: "🏥",
     description: "Privacy-compliant bestuurssoftware voor zorginstellingen",
     link: "/nl/industries/healthcare",
     features: [
@@ -33,6 +33,17 @@ const industries = [
       "Portefeuillebeheer",
       "Investeringsmonitoring",
       "Asset management"
+    ]
+  },
+  {
+    name: "Familiebedrijf",
+    icon: "👨‍👩‍👧‍👦",
+    description: "Bestuur en familieraad management voor multi-entiteit familiebedrijven",
+    link: "/nl/industries/family-business",
+    features: [
+      "Multi-entiteit governance",
+      "Beveiligde toegangscontrole",
+      "Generationele continuïteit"
     ]
   }
 ];


### PR DESCRIPTION
Adds Family Business as a new industry option in the navigation menu and industries overview pages.

### Changes
- Added Family Business to MegaMenu navigation in EN, FR, and NL
- Added Family Business to industries index pages in all languages
- Links to existing `/industries/family-business` page

Fixes #30

---

Generated with [Claude Code](https://claude.ai/code)