### PR TITLE
Add extra step to free trial activation flow

### DIFF
--- a/src/components/forms/TrialForm.astro
+++ b/src/components/forms/TrialForm.astro
@@ -35,6 +35,7 @@ interface Props {
   selectReasonText?: string;
   termsUrl?: string;
   privacyUrl?: string;
+  redirectUrl?: string;
 }
 
 const {
@@ -62,6 +63,7 @@ const {
   selectReasonText = "Select a reason",
   termsUrl = "/terms",
   privacyUrl = "/privacy",
+  redirectUrl = "/request-demo",
 } = Astro.props;
 ---
 
@@ -288,7 +290,7 @@ const {
   }
 </style>
 
-<script define:vars={{ TRIAL_API_URL, RECAPTCHA_EXECUTE_KEY }}>
+<script define:vars={{ TRIAL_API_URL, RECAPTCHA_EXECUTE_KEY, redirectUrl }}>
   document.addEventListener("DOMContentLoaded", () => {
     const form = document.getElementById("trialForm");
     const success = document.getElementById("formSuccess");
@@ -373,12 +375,12 @@ const {
             throw new Error("Failed to submit trial request");
           }
           const email = formData.get('email');
-          
+
           var myNewName = window.dataLayer || [];
           myNewName.push({'email': email});
 
-          form.classList.add("hidden");
-          success?.classList.remove("hidden");
+          // Redirect to demo booking page
+          window.location.href = redirectUrl + "?from=trial";
         });
       } catch (error) {
         console.error("Error submitting form:", error);

--- a/src/pages/fr/request-demo.astro
+++ b/src/pages/fr/request-demo.astro
@@ -123,6 +123,21 @@ const demoOutcomes = [
           <p class="text-xl text-gray-600 leading-relaxed max-w-3xl mx-auto">
             Planifiez une démonstration personnalisée pour voir comment Govrn peut transformer les opérations de votre conseil avec des insights IA et une collaboration fluide.
           </p>
+
+          <!-- Trial notification banner -->
+          <div id="trialNotification" class="hidden mt-8 max-w-2xl mx-auto bg-blue-50 border-2 border-blue-200 rounded-xl p-6">
+            <div class="flex items-start space-x-4">
+              <div class="flex-shrink-0">
+                <svg class="w-6 h-6 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+              </div>
+              <div class="flex-1">
+                <h3 class="text-lg font-semibold text-blue-900 mb-2">Presque terminé ! Une dernière étape</h3>
+                <p class="text-blue-800">Vos détails d'essai gratuit ont été soumis avec succès. Veuillez réserver une réunion avec notre expert ci-dessous. <strong>Votre essai gratuit commencera après cette réunion</strong>, où nous vous aiderons à vous installer et répondrons à toutes vos questions.</p>
+              </div>
+            </div>
+          </div>
         </div>
 
         <div class="grid lg:grid-cols-2 gap-16 items-start">
@@ -378,4 +393,19 @@ const demoOutcomes = [
       </div>
     </section>
   </main>
+
+  <script>
+    // Show trial notification if user came from trial form
+    document.addEventListener('DOMContentLoaded', () => {
+      const urlParams = new URLSearchParams(window.location.search);
+      if (urlParams.get('from') === 'trial') {
+        const notification = document.getElementById('trialNotification');
+        if (notification) {
+          notification.classList.remove('hidden');
+          // Scroll to the notification
+          notification.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        }
+      }
+    });
+  </script>
 </Layout>

--- a/src/pages/fr/try.astro
+++ b/src/pages/fr/try.astro
@@ -48,6 +48,7 @@ const trialFormProps = {
   },
   termsUrl: "/fr/terms",
   privacyUrl: "/fr/privacy",
+  redirectUrl: "/fr/request-demo",
   successTitle: "Bienvenue sur Govrn!",
   successMessage: "Votre compte d'essai est en cours de création. Vérifiez votre email pour les instructions de connexion."
 } 

--- a/src/pages/nl/request-demo.astro
+++ b/src/pages/nl/request-demo.astro
@@ -123,6 +123,21 @@ const demoUitkomsten = [
           <p class="text-xl text-gray-600 leading-relaxed max-w-3xl mx-auto">
             Plan een persoonlijke demo om te zien hoe Govrn uw bestuursprocessen kan transformeren met AI-gestuurde inzichten en naadloze samenwerking.
           </p>
+
+          <!-- Trial notification banner -->
+          <div id="trialNotification" class="hidden mt-8 max-w-2xl mx-auto bg-blue-50 border-2 border-blue-200 rounded-xl p-6">
+            <div class="flex items-start space-x-4">
+              <div class="flex-shrink-0">
+                <svg class="w-6 h-6 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+              </div>
+              <div class="flex-1">
+                <h3 class="text-lg font-semibold text-blue-900 mb-2">Bijna klaar! Nog één stap</h3>
+                <p class="text-blue-800">Uw gratis proefperiode gegevens zijn succesvol ingediend. Plan hieronder een afspraak met onze expert. <strong>Uw gratis proefperiode start na deze afspraak</strong>, waarin we u helpen instellen en al uw vragen beantwoorden.</p>
+              </div>
+            </div>
+          </div>
         </div>
 
         <div class="grid lg:grid-cols-2 gap-16 items-start">
@@ -378,4 +393,19 @@ const demoUitkomsten = [
       </div>
     </section>
   </main>
+
+  <script>
+    // Show trial notification if user came from trial form
+    document.addEventListener('DOMContentLoaded', () => {
+      const urlParams = new URLSearchParams(window.location.search);
+      if (urlParams.get('from') === 'trial') {
+        const notification = document.getElementById('trialNotification');
+        if (notification) {
+          notification.classList.remove('hidden');
+          // Scroll to the notification
+          notification.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        }
+      }
+    });
+  </script>
 </Layout>

--- a/src/pages/nl/try.astro
+++ b/src/pages/nl/try.astro
@@ -47,6 +47,7 @@ const trialFormProps = {
   },
   termsUrl: "/nl/terms",
   privacyUrl: "/nl/privacy",
+  redirectUrl: "/nl/request-demo",
   successTitle: "Welkom bij Govrn!",
   successMessage: "Uw proefaccount wordt aangemaakt. Controleer uw e-mail voor inloginstructies."
 } 

--- a/src/pages/request-demo.astro
+++ b/src/pages/request-demo.astro
@@ -146,6 +146,21 @@ const demoOutcomes = [
           <p class="text-xl text-gray-600 leading-relaxed max-w-3xl mx-auto">
             Schedule a personalized demo to see how Govrn can transform your board operations with AI-powered insights and seamless collaboration.
           </p>
+
+          <!-- Trial notification banner -->
+          <div id="trialNotification" class="hidden mt-8 max-w-2xl mx-auto bg-blue-50 border-2 border-blue-200 rounded-xl p-6">
+            <div class="flex items-start space-x-4">
+              <div class="flex-shrink-0">
+                <svg class="w-6 h-6 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+              </div>
+              <div class="flex-1">
+                <h3 class="text-lg font-semibold text-blue-900 mb-2">Almost there! One more step</h3>
+                <p class="text-blue-800">Your free trial details have been submitted successfully. Please book a meeting with our expert below. <strong>Your free trial will start after this meeting</strong>, where we'll help you get set up and answer any questions.</p>
+              </div>
+            </div>
+          </div>
         </div>
 
         <div class="grid lg:grid-cols-2 gap-16 items-start">
@@ -401,4 +416,19 @@ const demoOutcomes = [
       </div>
     </section>
   </main>
+
+  <script>
+    // Show trial notification if user came from trial form
+    document.addEventListener('DOMContentLoaded', () => {
+      const urlParams = new URLSearchParams(window.location.search);
+      if (urlParams.get('from') === 'trial') {
+        const notification = document.getElementById('trialNotification');
+        if (notification) {
+          notification.classList.remove('hidden');
+          // Scroll to the notification
+          notification.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        }
+      }
+    });
+  </script>
 </Layout>


### PR DESCRIPTION
After users submit the trial form, they are now redirected to the demo booking page where they must schedule a meeting with an expert. A prominent notification banner informs them that their free trial will start after the meeting.

## Changes
- Modified TrialForm to redirect to /request-demo after submission
- Added configurable redirectUrl prop for multilingual support
- Added notification banner on request-demo pages (EN/FR/NL)
- Banner displays when user comes from trial form (?from=trial)
- Updated all language versions (English, French, Dutch)

Closes #32

Generated with [Claude Code](https://claude.ai/code)