### PR TITLE
claude/validate-professional-email-yGQem

### DIFF
--- a/src/pages/request-demo.astro
+++ b/src/pages/request-demo.astro
@@ -164,7 +164,7 @@ const demoOutcomes = [
         </div>
 
         <div class="grid lg:grid-cols-2 gap-16 items-start">
-          <!-- Left Column - Calendly -->
+          <!-- Left Column - Form + Calendly -->
           <div class="bg-white rounded-2xl p-8 shadow-xl border border-gray-100">
             <!-- Expert Profile -->
             <div class="flex items-center space-x-4 mb-8 p-4 bg-gradient-to-r from-primary/5 to-blue-50 rounded-xl">
@@ -184,10 +184,96 @@ const demoOutcomes = [
               </div>
             </div>
 
-            <!-- Calendly inline widget begin -->
-            <div class="calendly-inline-widget" data-url="https://calendly.com/marketing-lech/30min-1?primary_color=3999de" style="min-width:320px;height:700px;"></div>
+            <!-- Pre-qualification Form -->
+            <form id="demoGateForm" class="space-y-5">
+              <div class="grid grid-cols-2 gap-4">
+                <div>
+                  <label for="firstName" class="block text-sm font-medium text-gray-700 mb-2">First Name</label>
+                  <input
+                    type="text"
+                    id="firstName"
+                    name="firstName"
+                    class="w-full px-4 py-3 rounded-lg border border-gray-300 focus:ring-2 focus:ring-primary focus:border-primary transition-colors"
+                    required
+                  />
+                </div>
+                <div>
+                  <label for="lastName" class="block text-sm font-medium text-gray-700 mb-2">Last Name</label>
+                  <input
+                    type="text"
+                    id="lastName"
+                    name="lastName"
+                    class="w-full px-4 py-3 rounded-lg border border-gray-300 focus:ring-2 focus:ring-primary focus:border-primary transition-colors"
+                    required
+                  />
+                </div>
+              </div>
+
+              <div>
+                <label for="email" class="block text-sm font-medium text-gray-700 mb-2">Work Email</label>
+                <input
+                  type="email"
+                  id="email"
+                  name="email"
+                  class="w-full px-4 py-3 rounded-lg border border-gray-300 focus:ring-2 focus:ring-primary focus:border-primary transition-colors"
+                  placeholder="name@company.com"
+                  required
+                />
+                <p id="emailError" class="hidden mt-2 text-sm text-red-600">
+                  Please use your professional email address (not gmail.com, hotmail.com, etc.)
+                </p>
+              </div>
+
+              <div>
+                <label for="company" class="block text-sm font-medium text-gray-700 mb-2">Company Name</label>
+                <input
+                  type="text"
+                  id="company"
+                  name="company"
+                  class="w-full px-4 py-3 rounded-lg border border-gray-300 focus:ring-2 focus:ring-primary focus:border-primary transition-colors"
+                  required
+                />
+              </div>
+
+              <div>
+                <label for="companyUrl" class="block text-sm font-medium text-gray-700 mb-2">Company Website</label>
+                <input
+                  type="url"
+                  id="companyUrl"
+                  name="companyUrl"
+                  class="w-full px-4 py-3 rounded-lg border border-gray-300 focus:ring-2 focus:ring-primary focus:border-primary transition-colors"
+                  placeholder="https://www.yourcompany.com"
+                  required
+                />
+                <p id="urlError" class="hidden mt-2 text-sm text-red-600">
+                  Please enter a valid company website URL
+                </p>
+              </div>
+
+              <button
+                type="submit"
+                class="w-full px-6 py-4 bg-primary text-white rounded-lg hover:bg-primary/90 transition-colors duration-200 font-medium flex items-center justify-center space-x-2"
+              >
+                <span>Continue to Schedule</span>
+                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7l5 5m0 0l-5 5m5-5H6"></path>
+                </svg>
+              </button>
+            </form>
+
+            <!-- Calendly inline widget (hidden initially) -->
+            <div id="calendlyContainer" class="hidden">
+              <div class="mb-4 p-4 bg-green-50 border border-green-200 rounded-lg">
+                <div class="flex items-center space-x-2">
+                  <svg class="w-5 h-5 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
+                  </svg>
+                  <span class="text-green-800 font-medium">Details confirmed! Now select your preferred time below.</span>
+                </div>
+              </div>
+              <div id="calendlyWidget" class="calendly-inline-widget" style="min-width:320px;height:700px;"></div>
+            </div>
             <script type="text/javascript" src="https://assets.calendly.com/assets/external/widget.js" async></script>
-            <!-- Calendly inline widget end -->
           </div>
 
           <!-- Right Column - Key Benefits -->
@@ -418,17 +504,201 @@ const demoOutcomes = [
   </main>
 
   <script>
-    // Show trial notification if user came from trial form
+    // List of personal email domains to block
+    const personalEmailDomains = [
+      'gmail.com',
+      'googlemail.com',
+      'hotmail.com',
+      'hotmail.co.uk',
+      'hotmail.fr',
+      'hotmail.de',
+      'hotmail.it',
+      'hotmail.es',
+      'outlook.com',
+      'outlook.fr',
+      'outlook.de',
+      'outlook.co.uk',
+      'live.com',
+      'live.co.uk',
+      'live.fr',
+      'live.nl',
+      'msn.com',
+      'yahoo.com',
+      'yahoo.co.uk',
+      'yahoo.fr',
+      'yahoo.de',
+      'yahoo.it',
+      'yahoo.es',
+      'ymail.com',
+      'aol.com',
+      'aol.co.uk',
+      'icloud.com',
+      'me.com',
+      'mac.com',
+      'protonmail.com',
+      'proton.me',
+      'mail.com',
+      'gmx.com',
+      'gmx.de',
+      'gmx.net',
+      'web.de',
+      'zoho.com',
+      'yandex.com',
+      'yandex.ru',
+      'inbox.com',
+      'fastmail.com',
+      'tutanota.com',
+      'mailinator.com',
+      'guerrillamail.com',
+      'tempmail.com',
+      'sharklasers.com',
+      'rediffmail.com',
+      'libero.it',
+      'virgilio.it',
+      'laposte.net',
+      'orange.fr',
+      'free.fr',
+      'wanadoo.fr',
+      'sfr.fr',
+      'bbox.fr',
+      't-online.de',
+      'bluewin.ch',
+      'telenet.be',
+      'skynet.be',
+      'proximus.be',
+      'ziggo.nl',
+      'kpnmail.nl',
+      'planet.nl',
+      'hetnet.nl',
+      'xs4all.nl'
+    ];
+
+    function isPersonalEmail(email) {
+      const domain = email.split('@')[1]?.toLowerCase();
+      return personalEmailDomains.includes(domain);
+    }
+
+    function isValidUrl(string) {
+      try {
+        const url = new URL(string);
+        return url.protocol === 'http:' || url.protocol === 'https:';
+      } catch (_) {
+        return false;
+      }
+    }
+
     document.addEventListener('DOMContentLoaded', () => {
+      // Show trial notification if user came from trial form
       const urlParams = new URLSearchParams(window.location.search);
       if (urlParams.get('from') === 'trial') {
         const notification = document.getElementById('trialNotification');
         if (notification) {
           notification.classList.remove('hidden');
-          // Scroll to the notification
           notification.scrollIntoView({ behavior: 'smooth', block: 'center' });
         }
       }
+
+      // Form handling
+      const form = document.getElementById('demoGateForm');
+      const emailInput = document.getElementById('email');
+      const emailError = document.getElementById('emailError');
+      const urlInput = document.getElementById('companyUrl');
+      const urlError = document.getElementById('urlError');
+      const calendlyContainer = document.getElementById('calendlyContainer');
+      const calendlyWidget = document.getElementById('calendlyWidget');
+
+      // Real-time email validation
+      emailInput?.addEventListener('blur', () => {
+        const email = emailInput.value;
+        if (email && isPersonalEmail(email)) {
+          emailError?.classList.remove('hidden');
+          emailInput.classList.add('border-red-500');
+          emailInput.classList.remove('border-gray-300');
+        } else {
+          emailError?.classList.add('hidden');
+          emailInput.classList.remove('border-red-500');
+          emailInput.classList.add('border-gray-300');
+        }
+      });
+
+      // Real-time URL validation
+      urlInput?.addEventListener('blur', () => {
+        const url = urlInput.value;
+        if (url && !isValidUrl(url)) {
+          urlError?.classList.remove('hidden');
+          urlInput.classList.add('border-red-500');
+          urlInput.classList.remove('border-gray-300');
+        } else {
+          urlError?.classList.add('hidden');
+          urlInput.classList.remove('border-red-500');
+          urlInput.classList.add('border-gray-300');
+        }
+      });
+
+      form?.addEventListener('submit', (e) => {
+        e.preventDefault();
+
+        const formData = new FormData(form);
+        const email = formData.get('email')?.toString() || '';
+        const companyUrl = formData.get('companyUrl')?.toString() || '';
+        const firstName = formData.get('firstName')?.toString() || '';
+        const lastName = formData.get('lastName')?.toString() || '';
+        const company = formData.get('company')?.toString() || '';
+
+        // Validate email
+        if (isPersonalEmail(email)) {
+          emailError?.classList.remove('hidden');
+          emailInput?.classList.add('border-red-500');
+          emailInput?.classList.remove('border-gray-300');
+          emailInput?.focus();
+          return;
+        }
+
+        // Validate URL
+        if (!isValidUrl(companyUrl)) {
+          urlError?.classList.remove('hidden');
+          urlInput?.classList.add('border-red-500');
+          urlInput?.classList.remove('border-gray-300');
+          urlInput?.focus();
+          return;
+        }
+
+        // Push to dataLayer for tracking
+        window.dataLayer = window.dataLayer || [];
+        window.dataLayer.push({
+          'event': 'demo_form_submit',
+          'email': email,
+          'company': company,
+          'companyUrl': companyUrl
+        });
+
+        // Hide form and show Calendly widget
+        form.classList.add('hidden');
+        calendlyContainer?.classList.remove('hidden');
+
+        // Build Calendly URL with prefilled data
+        const calendlyBaseUrl = 'https://calendly.com/marketing-lech/30min-1';
+        const calendlyParams = new URLSearchParams({
+          'primary_color': '3999de',
+          'name': `${firstName} ${lastName}`,
+          'email': email,
+          'a1': company,
+          'a2': companyUrl
+        });
+
+        // Set the Calendly widget URL
+        if (calendlyWidget) {
+          calendlyWidget.setAttribute('data-url', `${calendlyBaseUrl}?${calendlyParams.toString()}`);
+
+          // Reinitialize Calendly widget
+          if (window.Calendly) {
+            window.Calendly.initInlineWidget({
+              url: `${calendlyBaseUrl}?${calendlyParams.toString()}`,
+              parentElement: calendlyWidget
+            });
+          }
+        }
+      });
     });
   </script>
 </Layout>


### PR DESCRIPTION
- Add pre-qualification form before Calendly widget
- Validate that email is from a professional domain (blocks gmail, hotmail, etc.)
- Add company website URL field
- Show validation errors in real-time on blur
- Pass form data to Calendly widget after validation
- Track form submissions via dataLayer