### PR TITLE
Replace free trial form with expert consultation button

### DIFF
--- a/src/pages/fr/try.astro
+++ b/src/pages/fr/try.astro
@@ -1,6 +1,5 @@
 ---
 import Layout from '../../layouts/Layout.astro';
-import TrialForm from '../../components/forms/TrialForm.astro';
 
 const benefits = [
   {
@@ -9,7 +8,7 @@ const benefits = [
     description: "Commencez immédiatement avec notre plateforme complète"
   },
   {
-    icon: "🎯", 
+    icon: "🎯",
     title: "Sans carte bancaire",
     description: "Testez toutes les fonctionnalités sans risque pendant 14 jours"
   },
@@ -24,34 +23,6 @@ const benefits = [
     description: "Protection et cryptage de niveau bancaire dès le premier jour"
   }
 ];
-
-const trialFormProps = {
-  selectReasonText: "Sélectionnez un motif",
-  reasons: [
-    "Évaluation de solutions de gestion de conseil",
-    "Création d'un nouveau conseil", 
-    "Changement de plateforme",
-    "Amélioration de l'efficacité du conseil",
-    "Autre",
-  ],
-  labels: {
-    firstName: "Prénom",
-    lastName: "Nom", 
-    email: "Email professionnel",
-    company: "Nom de l'entreprise",
-    reason: "Motif de l'essai",
-    submit: "Commencer maintenant",
-    termsText: "En vous inscrivant, vous acceptez nos",
-    termsLink: "Conditions d'utilisation",
-    privacyLink: "Politique de confidentialité",
-    
-  },
-  termsUrl: "/fr/terms",
-  privacyUrl: "/fr/privacy",
-  redirectUrl: "/fr/request-demo",
-  successTitle: "Bienvenue sur Govrn!",
-  successMessage: "Votre compte d'essai est en cours de création. Vérifiez votre email pour les instructions de connexion."
-} 
 ---
 
 <Layout title="Essayez Govrn gratuitement - Optimisez la gestion de votre conseil" description="Découvrez comment Govrn peut transformer la gestion de votre conseil avec notre essai gratuit de 14 jours. Aucune carte bancaire requise.">
@@ -91,10 +62,29 @@ const trialFormProps = {
             </div>
           </div>
 
-          <!-- Colonne droite - Formulaire -->
-          <div class="bg-white rounded-2xl p-8 shadow-xl border border-gray-100">
-            <h2 class="text-2xl font-bold text-gray-900 mb-8">Activez votre essai gratuit</h2>
-            <TrialForm {...trialFormProps} />
+          <!-- Colonne droite - CTA -->
+          <div class="bg-white rounded-2xl p-10 shadow-xl border border-gray-100 text-center">
+            <div class="mb-8">
+              <div class="w-20 h-20 bg-primary/10 rounded-full flex items-center justify-center mx-auto mb-6">
+                <svg class="w-10 h-10 text-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"></path>
+                </svg>
+              </div>
+              <h2 class="text-2xl font-bold text-gray-900 mb-4">Démarrez avec l'aide d'un expert</h2>
+              <p class="text-lg text-gray-600 leading-relaxed">
+                Notre expert vous accompagnera personnellement pour configurer votre essai gratuit et vous garantir de tirer le meilleur parti de Govrn dès le premier jour.
+              </p>
+            </div>
+            <a
+              href="/fr/request-demo?from=trial"
+              class="inline-flex items-center justify-center w-full px-8 py-4 text-lg font-semibold text-white bg-primary hover:bg-primary/90 rounded-xl transition-all duration-200 shadow-lg hover:shadow-xl"
+            >
+              Commencer maintenant
+              <svg class="ml-2 w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7l5 5m0 0l-5 5m5-5H6"></path>
+              </svg>
+            </a>
+            <p class="mt-4 text-sm text-gray-500">Sans engagement</p>
           </div>
         </div>
       </div>

--- a/src/pages/nl/try.astro
+++ b/src/pages/nl/try.astro
@@ -1,6 +1,5 @@
 ---
 import Layout from '../../layouts/Layout.astro';
-import TrialForm from '../../components/forms/TrialForm.astro';
 
 const benefits = [
   {
@@ -9,7 +8,7 @@ const benefits = [
     description: "Begin meteen met ons complete platform"
   },
   {
-    icon: "🎯", 
+    icon: "🎯",
     title: "Geen creditcard nodig",
     description: "Test alle functies risicovrij gedurende 14 dagen"
   },
@@ -24,33 +23,6 @@ const benefits = [
     description: "Bankwaardige bescherming en versleuteling vanaf dag één"
   }
 ];
-
-const trialFormProps = {
-  selectReasonText: "Selecteer een reden",
-  reasons: [
-    "Evaluatie van bestuursbeheersystemen",
-    "Oprichting van een nieuw bestuur", 
-    "Overstap van platform",
-    "Verbetering van bestuursefficiëntie",
-    "Anders",
-  ],
-  labels: {
-    firstName: "Voornaam",
-    lastName: "Achternaam", 
-    email: "Zakelijk e-mailadres",
-    company: "Bedrijfsnaam",
-    reason: "Reden voor proefperiode",
-    submit: "Nu beginnen",
-    termsText: "Door u aan te melden, gaat u akkoord met onze",
-    termsLink: "Gebruiksvoorwaarden",
-    privacyLink: "Privacybeleid",
-  },
-  termsUrl: "/nl/terms",
-  privacyUrl: "/nl/privacy",
-  redirectUrl: "/nl/request-demo",
-  successTitle: "Welkom bij Govrn!",
-  successMessage: "Uw proefaccount wordt aangemaakt. Controleer uw e-mail voor inloginstructies."
-} 
 ---
 
 <Layout title="Probeer Govrn gratis - Optimaliseer uw bestuursbeheer" description="Ontdek hoe Govrn uw bestuursbeheer kan transformeren met onze gratis proefperiode van 14 dagen. Geen creditcard vereist.">
@@ -90,10 +62,29 @@ const trialFormProps = {
             </div>
           </div>
 
-          <!-- Rechterkolom - Formulier -->
-          <div class="bg-white rounded-2xl p-8 shadow-xl border border-gray-100">
-            <h2 class="text-2xl font-bold text-gray-900 mb-8">Activeer uw gratis proefperiode</h2>
-            <TrialForm {...trialFormProps} />
+          <!-- Rechterkolom - CTA -->
+          <div class="bg-white rounded-2xl p-10 shadow-xl border border-gray-100 text-center">
+            <div class="mb-8">
+              <div class="w-20 h-20 bg-primary/10 rounded-full flex items-center justify-center mx-auto mb-6">
+                <svg class="w-10 h-10 text-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"></path>
+                </svg>
+              </div>
+              <h2 class="text-2xl font-bold text-gray-900 mb-4">Start met begeleiding van een expert</h2>
+              <p class="text-lg text-gray-600 leading-relaxed">
+                Onze expert helpt u persoonlijk bij het opzetten van uw gratis proefperiode en zorgt ervoor dat u vanaf dag één het maximale uit Govrn haalt.
+              </p>
+            </div>
+            <a
+              href="/nl/request-demo?from=trial"
+              class="inline-flex items-center justify-center w-full px-8 py-4 text-lg font-semibold text-white bg-primary hover:bg-primary/90 rounded-xl transition-all duration-200 shadow-lg hover:shadow-xl"
+            >
+              Nu beginnen
+              <svg class="ml-2 w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7l5 5m0 0l-5 5m5-5H6"></path>
+              </svg>
+            </a>
+            <p class="mt-4 text-sm text-gray-500">Geen verplichting</p>
           </div>
         </div>
       </div>

--- a/src/pages/try.astro
+++ b/src/pages/try.astro
@@ -1,6 +1,5 @@
 ---
 import Layout from '../layouts/Layout.astro';
-import TrialForm from '../components/forms/TrialForm.astro';
 
 const benefits = [
   {
@@ -63,10 +62,29 @@ const benefits = [
             </div>
           </div>
 
-          <!-- Right Column - Form -->
-          <div class="bg-white rounded-2xl p-8 shadow-xl border border-gray-100">
-            <h2 class="text-2xl font-bold text-gray-900 mb-8">Activate Your Free Trial</h2>
-            <TrialForm />
+          <!-- Right Column - CTA -->
+          <div class="bg-white rounded-2xl p-10 shadow-xl border border-gray-100 text-center">
+            <div class="mb-8">
+              <div class="w-20 h-20 bg-primary/10 rounded-full flex items-center justify-center mx-auto mb-6">
+                <svg class="w-10 h-10 text-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"></path>
+                </svg>
+              </div>
+              <h2 class="text-2xl font-bold text-gray-900 mb-4">Get Started with Expert Guidance</h2>
+              <p class="text-lg text-gray-600 leading-relaxed">
+                Our expert will personally help you set up your free trial and ensure you get the most out of Govrn from day one.
+              </p>
+            </div>
+            <a
+              href="/request-demo?from=trial"
+              class="inline-flex items-center justify-center w-full px-8 py-4 text-lg font-semibold text-white bg-primary hover:bg-primary/90 rounded-xl transition-all duration-200 shadow-lg hover:shadow-xl"
+            >
+              Start Now
+              <svg class="ml-2 w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7l5 5m0 0l-5 5m5-5H6"></path>
+              </svg>
+            </a>
+            <p class="mt-4 text-sm text-gray-500">No commitment required</p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Remove the trial form from /try pages and replace it with a prominent "Start Now" button that redirects users to the request-demo page. The new design includes messaging that an expert will help set up the free trial, providing a more personal onboarding experience.

Changes applied to EN, FR, and NL versions of the page.